### PR TITLE
Allow skipping message deletion for specific channels

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -191,7 +191,7 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 			if msg.Hit {
 				// The message might be an action rather than text. Actions aren't deletable.
 				// An example of an action is a call request.
-				if msg.Type == UserMessage && !c.SkipChannel(msg.ChannelID) {
+				if msg.Type == UserMessage {
 					log.Infof("Deleting message %v from channel %v", msg.ID, msg.ChannelID)
 					if c.dryRun {
 						// Move seek index forward to simulate message deletion on server's side

--- a/client/api.go
+++ b/client/api.go
@@ -58,7 +58,8 @@ func (c *Client) SetChannels(channels string) {
 
 func (c *Client) SkipChannel(channel string) bool {
 	for _, channel_ := range c.channels {
-		if channel_ == channel {
+		if channel == channel_ {
+			log.Debugf("Skipping message deletion for channel/guild %v", channel)
 			return true
 		}
 	}
@@ -187,7 +188,7 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 			if msg.Hit {
 				// The message might be an action rather than text. Actions aren't deletable.
 				// An example of an action is a call request.
-				if msg.Type == UserMessage {
+				if msg.Type == UserMessage && !c.SkipChannel(msg.ChannelID) {
 					log.Infof("Deleting message %v from channel %v", msg.ID, msg.ChannelID)
 					if c.dryRun {
 						// Move seek index forward to simulate message deletion on server's side

--- a/client/api.go
+++ b/client/api.go
@@ -15,9 +15,9 @@ const api = "https://discord.com/api/v6"
 const messageLimit = 25
 
 var endpoints = map[string]string{
-	"me":            "/users/@me",
-	"relationships": "/users/@me/relationships",
-	"guilds":        "/users/@me/guilds",
+	"me":             "/users/@me",
+	"relationships":  "/users/@me/relationships",
+	"guilds":         "/users/@me/guilds",
 	"guild_channels": "/guilds/%v/channels",
 	"guild_msgs": "/guilds/%v/messages/search" +
 		"?author_id=%v" +
@@ -58,8 +58,8 @@ func (c *Client) SetChannels(channels string) {
 }
 
 func (c *Client) SkipChannel(channel string) bool {
-	for _, channel_ := range c.channels {
-		if channel == channel_ {
+	for _, ChannelCmp := range c.channels {
+		if channel == ChannelCmp {
 			log.Infof("Skipping message deletion for channel/guild %v", channel)
 			return true
 		}

--- a/client/api.go
+++ b/client/api.go
@@ -109,9 +109,11 @@ Relationships:
 
 		log.Infof("Resolved relationship with '%v' to channel %v", relation.Recipient.Username, channel.ID)
 
-		err = c.DeleteFromChannel(me, channel)
-		if err != nil {
-			return err
+		if !c.SkipChannel(channel.ID) {
+			err = c.DeleteFromChannel(me, channel)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/client/api.go
+++ b/client/api.go
@@ -18,6 +18,7 @@ var endpoints = map[string]string{
 	"me":            "/users/@me",
 	"relationships": "/users/@me/relationships",
 	"guilds":        "/users/@me/guilds",
+	"guild_channels": "/guilds/%v/channels",
 	"guild_msgs": "/guilds/%v/messages/search" +
 		"?author_id=%v" +
 		"&include_nsfw=true" +
@@ -59,7 +60,7 @@ func (c *Client) SetChannels(channels string) {
 func (c *Client) SkipChannel(channel string) bool {
 	for _, channel_ := range c.channels {
 		if channel == channel_ {
-			log.Debugf("Skipping message deletion for channel/guild %v", channel)
+			log.Infof("Skipping message deletion for channel/guild %v", channel)
 			return true
 		}
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -37,7 +37,7 @@ type Client struct {
 	requestCount int
 	dryRun       bool
 	token        string
-	channels	 []string
+	channels     []string
 	httpClient   http.Client
 }
 

--- a/client/api.go
+++ b/client/api.go
@@ -77,9 +77,11 @@ func (c *Client) PartialDelete() error {
 		return errors.Wrap(err, "Error fetching channels")
 	}
 	for _, channel := range channels {
-		err = c.DeleteFromChannel(me, &channel)
-		if err != nil {
-			return err
+		if !c.SkipChannel(channel.ID) {
+			err = c.DeleteFromChannel(me, &channel)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -185,7 +187,7 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 				// An example of an action is a call request.
 				if msg.Type == UserMessage {
 					log.Infof("Deleting message %v from channel %v", msg.ID, msg.ChannelID)
-					if c.dryRun || c.SkipChannel(msg.ChannelID) {
+					if c.dryRun {
 						// Move seek index forward to simulate message deletion on server's side
 						(*seek)++
 					} else {

--- a/client/api.go
+++ b/client/api.go
@@ -119,9 +119,11 @@ Relationships:
 		return errors.Wrap(err, "Error fetching guilds")
 	}
 	for _, channel := range guilds {
-		err = c.DeleteFromGuild(me, &channel)
-		if err != nil {
-			return err
+		if !c.SkipChannel(channel.ID) {
+			err = c.DeleteFromGuild(me, &channel)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/client/response.go
+++ b/client/response.go
@@ -76,26 +76,26 @@ func (c *Client) Guilds() ([]Channel, error) {
 }
 
 func (c *Client) GuildMessages(channel *Channel, me *Me, seek *int) (*Messages, error) {
-	endpoint := fmt.Sprintf(endpoints["guild_msgs"], channel.ID, me.ID, *seek, messageLimit)
-	endpoint_ := fmt.Sprintf(endpoints["guild_channels"], channel.ID)
+	endpointMsgs := fmt.Sprintf(endpoints["guild_msgs"], channel.ID, me.ID, *seek, messageLimit)
+	endpointChannels := fmt.Sprintf(endpoints["guild_channels"], channel.ID)
 
 	var channels []Me
 	var results Messages
 
-	err := c.request("GET", endpoint_, nil, &channels)
-	if err != nil {
-		return nil, err
+	errChannels := c.request("GET", endpointChannels, nil, &channels)
+	if errChannels != nil {
+		return nil, errChannels
 	}
 
 	for _, channel := range channels {
 		if !c.SkipChannel(channel.ID) {
-			endpoint = fmt.Sprintf("%v&channel_id=%v", endpoint, channel.ID)
+			endpointMsgs = fmt.Sprintf("%v&channel_id=%v", endpointMsgs, channel.ID)
 		}
 	}
 
-	err_ := c.request("GET", endpoint, nil, &results)
-	if err_ != nil {
-		return nil, err
+	errMsgs := c.request("GET", endpointMsgs, nil, &results)
+	if errMsgs != nil {
+		return nil, errMsgs
 	}
 
 	return &results, nil

--- a/client/response.go
+++ b/client/response.go
@@ -77,9 +77,24 @@ func (c *Client) Guilds() ([]Channel, error) {
 
 func (c *Client) GuildMessages(channel *Channel, me *Me, seek *int) (*Messages, error) {
 	endpoint := fmt.Sprintf(endpoints["guild_msgs"], channel.ID, me.ID, *seek, messageLimit)
-	var results Messages
-	err := c.request("GET", endpoint, nil, &results)
+	endpoint_ := fmt.Sprintf(endpoints["guild_channels"], channel.ID)
+
+	var channels []Me
+	var results  Messages
+
+	err := c.request("GET", endpoint_, nil, &channels)
 	if err != nil {
+		return nil, err
+	}
+
+	for _, channel_ := range channels {
+		if !c.SkipChannel(channel_.ID) {
+			endpoint = fmt.Sprintf("%v&channel_id=%v", endpoint, channel_.ID)
+		}
+	}
+
+	err_ := c.request("GET", endpoint, nil, &results)
+	if err_ != nil {
 		return nil, err
 	}
 

--- a/client/response.go
+++ b/client/response.go
@@ -80,16 +80,16 @@ func (c *Client) GuildMessages(channel *Channel, me *Me, seek *int) (*Messages, 
 	endpoint_ := fmt.Sprintf(endpoints["guild_channels"], channel.ID)
 
 	var channels []Me
-	var results  Messages
+	var results Messages
 
 	err := c.request("GET", endpoint_, nil, &channels)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, channel_ := range channels {
-		if !c.SkipChannel(channel_.ID) {
-			endpoint = fmt.Sprintf("%v&channel_id=%v", endpoint, channel_.ID)
+	for _, channel := range channels {
+		if !c.SkipChannel(channel.ID) {
+			endpoint = fmt.Sprintf("%v&channel_id=%v", endpoint, channel.ID)
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var partialCmd = &cobra.Command{
 
 func init() {
 	partialCmd.Flags().BoolVarP(&dryrun, "dry-run", "d", false, "perform dry run without deleting anything")
-	partialCmd.Flags().StringVarP(&channels, "skip-channel", "s", "", "skip message deletion for specified channels")
+	partialCmd.Flags().StringVarP(&channels, "skip", "s", "", "skip message deletion for specified channels")
 
 
 	rootCmd.AddCommand(partialCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var partialCmd = &cobra.Command{
 
 func init() {
 	partialCmd.Flags().BoolVarP(&dryrun, "dry-run", "d", false, "perform dry run without deleting anything")
-	partialCmd.Flags().StringVarP(&channels, "skip", "s", "", "skip message deletion for specified channels")
+	partialCmd.Flags().StringVarP(&channels, "skip", "s", "", "skip message deletion for specified channels/guilds")
 
 	rootCmd.AddCommand(partialCmd)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,6 @@ func init() {
 	partialCmd.Flags().BoolVarP(&dryrun, "dry-run", "d", false, "perform dry run without deleting anything")
 	partialCmd.Flags().StringVarP(&channels, "skip", "s", "", "skip message deletion for specified channels")
 
-
 	rootCmd.AddCommand(partialCmd)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 
 var verbose bool
 var dryrun bool
+var channels string
 
 var rootCmd = &cobra.Command{
 	Use:   "discord-delete",
@@ -38,7 +39,9 @@ var partialCmd = &cobra.Command{
 		}
 
 		client := client.New(tok)
+
 		client.SetDryRun(dryrun)
+		client.SetChannels(channels)
 
 		err = client.PartialDelete()
 		if err != nil {
@@ -49,6 +52,8 @@ var partialCmd = &cobra.Command{
 
 func init() {
 	partialCmd.Flags().BoolVarP(&dryrun, "dry-run", "d", false, "perform dry run without deleting anything")
+	partialCmd.Flags().StringVarP(&channels, "skip-channel", "s", "", "skip message deletion for specified channels")
+
 
 	rootCmd.AddCommand(partialCmd)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging")


### PR DESCRIPTION
Allows skipping channels/guilds/DMs with the `-s` flag
`discord-delete partial -s "777867765434664961 735863939876343539"`

Closes #26