### PR TITLE
Change channel skipping algorithm to avoid using &channel_id

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -114,8 +114,13 @@ Relationships:
 	if err != nil {
 		return errors.Wrap(err, "Error fetching guilds")
 	}
-	for _, channel := range guilds {
-		err = c.DeleteFromGuild(me, &channel)
+	for _, guild := range guilds {
+		if c.skipChannel(guild.ID) {
+			log.Infof("Skipping message deletion for guild '%v'", guild.Name)
+			continue
+		}
+
+		err = c.DeleteFromGuild(me, &guild)
 		if err != nil {
 			return err
 		}

--- a/client/api.go
+++ b/client/api.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -38,7 +37,7 @@ type Client struct {
 	requestCount int
 	dryRun       bool
 	token        string
-	channels     []string
+	skipChannels []string
 	httpClient   http.Client
 }
 
@@ -53,19 +52,8 @@ func (c *Client) SetDryRun(dryRun bool) {
 	c.dryRun = dryRun
 }
 
-func (c *Client) SetChannels(channels string) {
-	c.channels = strings.Fields(channels)
-}
-
-func (c *Client) SkipChannel(channel string) bool {
-	for _, ChannelCmp := range c.channels {
-		if channel == ChannelCmp {
-			log.Infof("Skipping message deletion for channel/guild %v", channel)
-			return true
-		}
-	}
-
-	return false
+func (c *Client) SetSkipChannels(skipChannels []string) {
+	c.skipChannels = skipChannels
 }
 
 func (c *Client) PartialDelete() error {
@@ -78,12 +66,16 @@ func (c *Client) PartialDelete() error {
 	if err != nil {
 		return errors.Wrap(err, "Error fetching channels")
 	}
+
 	for _, channel := range channels {
-		if !c.SkipChannel(channel.ID) {
-			err = c.DeleteFromChannel(me, &channel)
-			if err != nil {
-				return err
-			}
+		if c.skipChannel(channel.ID) {
+			log.Infof("Skipping message deletion for channel %v", channel.ID)
+			continue
+		}
+
+		err = c.DeleteFromChannel(me, &channel)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -110,7 +102,7 @@ Relationships:
 
 		log.Infof("Resolved relationship with '%v' to channel %v", relation.Recipient.Username, channel.ID)
 
-		if !c.SkipChannel(channel.ID) {
+		if !c.skipChannel(channel.ID) {
 			err = c.DeleteFromChannel(me, channel)
 			if err != nil {
 				return err
@@ -123,11 +115,9 @@ Relationships:
 		return errors.Wrap(err, "Error fetching guilds")
 	}
 	for _, channel := range guilds {
-		if !c.SkipChannel(channel.ID) {
-			err = c.DeleteFromGuild(me, &channel)
-			if err != nil {
-				return err
-			}
+		err = c.DeleteFromGuild(me, &channel)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -187,29 +177,11 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 	const minSleep = 200
 
 	for _, ctx := range messages.ContextMessages {
+		var hit *Message
+
 		for _, msg := range ctx {
 			if msg.Hit {
-				// The message might be an action rather than text. Actions aren't deletable.
-				// An example of an action is a call request.
-				if msg.Type == UserMessage {
-					log.Infof("Deleting message %v from channel %v", msg.ID, msg.ChannelID)
-					if c.dryRun {
-						// Move seek index forward to simulate message deletion on server's side
-						(*seek)++
-					} else {
-						err := c.DeleteMessage(&msg)
-						if err != nil {
-							return errors.Wrap(err, "Error deleting message")
-						}
-						time.Sleep(minSleep * time.Millisecond)
-					}
-					// Increment regardless of whether it's a dry run
-					c.deletedCount++
-				} else {
-					log.Debugf("Found message of non-zero type, incrementing seek index")
-					(*seek)++
-				}
-
+				hit = &msg
 				break
 			}
 
@@ -217,9 +189,55 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 			// by the current user.
 			log.Debugf("Skipping context message")
 		}
+
+		if hit != nil {
+			// The message might be an action rather than text. Actions aren't deletable.
+			// An example of an action is a call request.
+			if hit.Type != UserMessage {
+				log.Debugf("Found message of non-zero type, incrementing seek index")
+				(*seek)++
+				continue
+			}
+
+			// Check if this message is in our list of channels to skip
+			// This will only skip this specific message and increment the seek index
+			// Entire channels should be skipped at the caller of this function
+			// We do it this way because we search guilds returns a mix of messages from
+			// any channel
+			if c.skipChannel(hit.ChannelID) {
+				log.Infof("Skipping message deletion for channel %v", hit.ChannelID)
+				(*seek)++
+				continue
+			}
+
+			log.Infof("Deleting message %v from channel %v", hit.ID, hit.ChannelID)
+			if c.dryRun {
+				// Move seek index forward to simulate message deletion on server's side
+				(*seek)++
+			} else {
+				err := c.DeleteMessage(hit)
+				if err != nil {
+					return errors.Wrap(err, "Error deleting message")
+				}
+				time.Sleep(minSleep * time.Millisecond)
+			}
+			// Increment regardless of whether it's a dry run
+			c.deletedCount++
+
+			break
+		}
 	}
 
 	return nil
+}
+
+func (c *Client) skipChannel(channel string) bool {
+	for _, skip := range c.skipChannels {
+		if channel == skip {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) request(method string, endpoint string, reqData interface{}, resData interface{}) error {

--- a/client/response.go
+++ b/client/response.go
@@ -76,26 +76,13 @@ func (c *Client) Guilds() ([]Channel, error) {
 }
 
 func (c *Client) GuildMessages(channel *Channel, me *Me, seek *int) (*Messages, error) {
-	endpointMsgs := fmt.Sprintf(endpoints["guild_msgs"], channel.ID, me.ID, *seek, messageLimit)
-	endpointChannels := fmt.Sprintf(endpoints["guild_channels"], channel.ID)
+	endpoint := fmt.Sprintf(endpoints["guild_msgs"], channel.ID, me.ID, *seek, messageLimit)
 
-	var channels []Me
 	var results Messages
 
-	errChannels := c.request("GET", endpointChannels, nil, &channels)
-	if errChannels != nil {
-		return nil, errChannels
-	}
-
-	for _, channel := range channels {
-		if !c.SkipChannel(channel.ID) {
-			endpointMsgs = fmt.Sprintf("%v&channel_id=%v", endpointMsgs, channel.ID)
-		}
-	}
-
-	errMsgs := c.request("GET", endpointMsgs, nil, &results)
-	if errMsgs != nil {
-		return nil, errMsgs
+	err := c.request("GET", endpoint, nil, &results)
+	if err != nil {
+		return nil, err
 	}
 
 	return &results, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 var verbose bool
 var dryrun bool
-var channels string
+var skipChannels []string
 
 var rootCmd = &cobra.Command{
 	Use:   "discord-delete",
@@ -41,7 +41,7 @@ var partialCmd = &cobra.Command{
 		client := client.New(tok)
 
 		client.SetDryRun(dryrun)
-		client.SetChannels(channels)
+		client.SetSkipChannels(skipChannels)
 
 		err = client.PartialDelete()
 		if err != nil {
@@ -52,7 +52,7 @@ var partialCmd = &cobra.Command{
 
 func init() {
 	partialCmd.Flags().BoolVarP(&dryrun, "dry-run", "d", false, "perform dry run without deleting anything")
-	partialCmd.Flags().StringVarP(&channels, "skip", "s", "", "skip message deletion for specified channels/guilds")
+	partialCmd.Flags().StringSliceVarP(&skipChannels, "skip", "s", []string{}, "skip message deletion for specified channels/guilds")
 
 	rootCmd.AddCommand(partialCmd)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose logging")


### PR DESCRIPTION
Hey @git-bruh, apologies, your original skipping algorithm was actually perfectly fine. This pull request takes some inspiration from there to avoid the problem mentioned in #27.

I also changed the parameter usage so that you pass it multiple times to skip multiple channels. Like so: `-s 1234... -s 1234...`

This will need a bit of docs in the wiki before a release can be made so nobody misuses the feature.