### PR TITLE
On error deleting individual message, continue and log, do not stop.

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -218,9 +218,9 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 				(*seek)++
 			} else {
 				err := c.DeleteMessage(&msg)
-      if err != nil {
-        log.Infof("--- Error deleting message")
-      }
+				if err != nil {
+					log.Infof("--- Error deleting message")
+				}
 				time.Sleep(minSleep * time.Millisecond)
 			}
 			// Increment regardless of whether it's a dry run

--- a/client/api.go
+++ b/client/api.go
@@ -218,10 +218,9 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 				(*seek)++
 			} else {
 				err := c.DeleteMessage(&msg)
-				if err != nil {
-          //return errors.Wrap(err, "Error deleting message")
-					log.Infof("--- Error deleting message")
-				}
+      if err != nil {
+        log.Infof("--- Error deleting message")
+      }
 				time.Sleep(minSleep * time.Millisecond)
 			}
 			// Increment regardless of whether it's a dry run

--- a/client/api.go
+++ b/client/api.go
@@ -219,7 +219,8 @@ func (c *Client) DeleteMessages(messages *Messages, seek *int) error {
 			} else {
 				err := c.DeleteMessage(&msg)
 				if err != nil {
-					return errors.Wrap(err, "Error deleting message")
+          //return errors.Wrap(err, "Error deleting message")
+					log.Infof("--- Error deleting message")
 				}
 				time.Sleep(minSleep * time.Millisecond)
 			}


### PR DESCRIPTION
I have seen a couple of instances where one or two individual items cannot be deleted due to being in channels that no longer exist or are now hidden or something.   It is better to just log that error for that one message unable to be deleted, and continue and process the rest.